### PR TITLE
Feature/dvop 2453

### DIFF
--- a/ansible/group_vars/artifactory/vars
+++ b/ansible/group_vars/artifactory/vars
@@ -1,2 +1,2 @@
 ---
-artifactory_version: 7.41.12
+artifactory_version: 7.63.12

--- a/ansible/roles/artifactory/defaults/main.yaml
+++ b/ansible/roles/artifactory/defaults/main.yaml
@@ -1,2 +1,2 @@
-artifactory_version: "7.41.12"
+artifactory_version: "7.63.12"
 artifactory_package: "jfrog-artifactory-pro-{{ artifactory_version }}.rpm"

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -14,24 +14,18 @@
     state: latest
 
 -  name: reboot the server
-   shell: 'sleep 1 && shutdown -r now "Reboot triggered by Ansible" && sleep 1'
+   shell: (sleep 2 && shutdown -r now) &
    async: 1
-   poll: 1
+   poll: 0
    ignore_errors: true
-   become: true
-#   shell: (sleep 2 && shutdown -r now) &
-#   async: 1
-#   poll: 0
-#   ignore_errors: true
 
-
-#-  name: Wait for the reboot and reconnect
-#   wait_for:
-#     host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
-#     port: 22
-#     delay: 10
-#     search_regex: OpenSSH
-#   connection: local
+-  name: Wait for the reboot and reconnect
+   wait_for:
+     port: 22
+     host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
+     search_regex: OpenSSH
+     delay: 10
+   connection: local
 
 - name: Create temporary build directory to install artifactory
   tempfile:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -8,6 +8,11 @@
     ]
     umask: "0022"
 
+- name: upgrade all packages
+  yum: 
+    name: '*'
+    state: latest
+
 - name: Create temporary build directory to install artifactory
   tempfile:
     state: directory
@@ -53,3 +58,6 @@
     dest: "/etc/profile.d/artifactory.sh"
     content: |
       export JFROG_HOME="/opt/jfrog"
+
+- name: Unconditionally reboot the machine with all defaults
+  reboot:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -14,18 +14,24 @@
     state: latest
 
 -  name: reboot the server
-   shell: (sleep 2 && shutdown -r now) &
+   shell: 'sleep 1 && shutdown -r now "Reboot triggered by Ansible" && sleep 1'
    async: 1
    poll: 0
    ignore_errors: true
+   become: true
+#   shell: (sleep 2 && shutdown -r now) &
+#   async: 1
+#   poll: 0
+#   ignore_errors: true
 
--  name: Wait for the reboot and reconnect
-   wait_for:
-     host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
-     port: 22
-     delay: 10
-     search_regex: OpenSSH
-   connection: local
+
+#-  name: Wait for the reboot and reconnect
+#   wait_for:
+#     host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
+#     port: 22
+#     delay: 10
+#     search_regex: OpenSSH
+#   connection: local
 
 - name: Create temporary build directory to install artifactory
   tempfile:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -13,6 +13,22 @@
     name: '*'
     state: latest
 
+-  name: reboot the server
+   shell: 'sleep 1 && shutdown -r now "Reboot triggered by Ansible" && sleep 1'
+   async: 1
+   poll: 0
+   ignore_errors: true
+   become: true
+
+-  name: Wait for the reboot and reconnect
+   wait_for:
+     port: 22
+     host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
+     search_regex: OpenSSH
+     delay: 10
+     timeout: 60
+   connection: local
+
 - name: Create temporary build directory to install artifactory
   tempfile:
     state: directory
@@ -58,6 +74,3 @@
     dest: "/etc/profile.d/artifactory.sh"
     content: |
       export JFROG_HOME="/opt/jfrog"
-
-- name: Unconditionally reboot the machine with all defaults
-  reboot:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -21,10 +21,10 @@
 
 -  name: Wait for the reboot and reconnect
    wait_for:
-     host: "{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}"
+     host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
      port: 22
-     delay: 15
-   delegate_to: localhost
+     delay: 10
+   connection: local
 
 - name: Create temporary build directory to install artifactory
   tempfile:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -17,7 +17,6 @@
    command: /sbin/reboot
 
 -  name: Wait for the reboot and reconnect
-   sudo: no
    local_action:
      module: wait_for
        host="{{ inventory_hostname }}"

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -24,6 +24,7 @@
      host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
      port: 22
      delay: 10
+     search_regex: OpenSSH
    connection: local
 
 - name: Create temporary build directory to install artifactory

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -21,13 +21,12 @@
    become: true
 
 -  name: Wait for the reboot and reconnect
-   wait_for:
-     port: 22
-     host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
-     search_regex: OpenSSH
-     delay: 10
-     timeout: 60
-   connection: local
+   local_action:
+     module: wait_for
+       host={{ inventory_hostname }}
+       port=22
+       delay=10
+     become: false
 
 - name: Create temporary build directory to install artifactory
   tempfile:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -16,7 +16,7 @@
 -  name: reboot the server
    shell: 'sleep 1 && shutdown -r now "Reboot triggered by Ansible" && sleep 1'
    async: 1
-   poll: 0
+   poll: 1
    ignore_errors: true
    become: true
 #   shell: (sleep 2 && shutdown -r now) &

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -21,12 +21,13 @@
    become: true
 
 -  name: Wait for the reboot and reconnect
-   local_action:
-     module: wait_for
-       host={{ inventory_hostname }}
-       port=22
-       delay=10
-     become: false
+   wait_for:
+     port: 22
+     host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
+     search_regex: OpenSSH
+     delay: 10
+     timeout: 60
+   connection: local
 
 - name: Create temporary build directory to install artifactory
   tempfile:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -13,18 +13,25 @@
     name: '*'
     state: latest
 
--  name: reboot the server
-   shell: (sleep 2 && shutdown -r now) &
-   async: 1
-   poll: 0
-   ignore_errors: true
+- name: Reboot the server
+  reboot:
+    connect_timeout: 60
+    post_reboot_delay: 20
+    test_command: "whoami"
+    msg: "Reboot initiated by Ansible"
 
--  name: Wait for the reboot
-   wait_for_connection:
-     connect_timeout: 60
-     sleep: 5
-     delay: 5
-     timeout: 120
+#-  name: reboot the server
+#   shell: (sleep 2 && shutdown -r now) &
+#   async: 1
+#   poll: 0
+#   ignore_errors: true
+
+#-  name: Wait for the reboot
+#   wait_for_connection:
+#     connect_timeout: 60
+#     sleep: 5
+#     delay: 5
+#     timeout: 120
 
 - name: Create temporary build directory to install artifactory
   tempfile:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -16,8 +16,8 @@
 - name: Reboot the server
   reboot:
     connect_timeout: 60
-    post_reboot_delay: 20
-    test_command: "whoami"
+    post_reboot_delay: 60
+    #test_command: "whoami"
     msg: "Reboot initiated by Ansible"
 
 #-  name: reboot the server

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -14,20 +14,17 @@
     state: latest
 
 -  name: reboot the server
-   shell: 'sleep 1 && shutdown -r now "Reboot triggered by Ansible" && sleep 1'
-   async: 1
-   poll: 0
-   ignore_errors: true
-   become: true
+   command: /sbin/reboot
 
 -  name: Wait for the reboot and reconnect
-   wait_for:
-     port: 22
-     host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
-     search_regex: OpenSSH
-     delay: 10
-     timeout: 60
-   connection: local
+   sudo: no
+   local_action:
+     module: wait_for
+       host="{{ inventory_hostname }}"
+       search_regex=OpenSSH
+       port=22
+       delay=1
+       timeout=300
 
 - name: Create temporary build directory to install artifactory
   tempfile:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -19,13 +19,12 @@
    poll: 0
    ignore_errors: true
 
--  name: Wait for the reboot and reconnect
-   wait_for:
-     port: 22
-     host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
-     search_regex: OpenSSH
-     delay: 10
-   connection: local
+-  name: Wait for the reboot
+   wait_for_connection:
+     connect_timeout: 60
+     sleep: 5
+     delay: 5
+     timeout: 120
 
 - name: Create temporary build directory to install artifactory
   tempfile:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -14,16 +14,17 @@
     state: latest
 
 -  name: reboot the server
-   command: /sbin/reboot
+   shell: (sleep 2 && shutdown -r now) &
+   async: 1
+   poll: 0
+   ignore_errors: true
 
 -  name: Wait for the reboot and reconnect
-   local_action:
-     module: wait_for
-       host="{{ inventory_hostname }}"
-       search_regex=OpenSSH
-       port=22
-       delay=1
-       timeout=300
+   wait_for:
+     host: "{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}"
+     port: 22
+     delay: 15
+   delegate_to: localhost
 
 - name: Create temporary build directory to install artifactory
   tempfile:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -15,23 +15,9 @@
 
 - name: Reboot the server
   reboot:
-    connect_timeout: 60
-    post_reboot_delay: 60
-    #test_command: "whoami"
+    connect_timeout: 90
+    post_reboot_delay: 90
     msg: "Reboot initiated by Ansible"
-
-#-  name: reboot the server
-#   shell: (sleep 2 && shutdown -r now) &
-#   async: 1
-#   poll: 0
-#   ignore_errors: true
-
-#-  name: Wait for the reboot
-#   wait_for_connection:
-#     connect_timeout: 60
-#     sleep: 5
-#     delay: 5
-#     timeout: 120
 
 - name: Create temporary build directory to install artifactory
   tempfile:

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -12,7 +12,7 @@ source "amazon-ebs" "builder" {
   iam_instance_profile  = "packer-builders-${var.aws_region}"
 
   launch_block_device_mappings {
-    device_name = "/dev/sda1"
+    device_name = "/dev/xvda"
     volume_size = var.root_volume_size_gb
     volume_type = "gp2"
     delete_on_termination = true

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -25,6 +25,13 @@ source "amazon-ebs" "builder" {
     delete_on_termination = true
   }
 
+  launch_block_device_mappings {
+    device_name = "/dev/xvdc"
+    volume_size = var.extract_volume_size_gb
+    volume_type = "gp2"
+    delete_on_termination = true
+  }
+
   security_group_filter {
     filters = {
       "group-name": "packer-builders-${var.aws_region}"

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -20,7 +20,7 @@ source "amazon-ebs" "builder" {
 
   launch_block_device_mappings {
     device_name = "/dev/xvdb"
-    volume_size = var.data_volume_size_gib
+    volume_size = var.data_volume_size_gb
     volume_type = "gp2"
     delete_on_termination = true
   }

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -16,7 +16,6 @@ source "amazon-ebs" "builder" {
     volume_size           = var.root_volume_size_gb
     volume_type           = "gp2"
     delete_on_termination = var.volume_delete_on_termination
-    encrypted             = var.volume_encrypted
   }
 
   launch_block_device_mappings {
@@ -24,7 +23,6 @@ source "amazon-ebs" "builder" {
     volume_size           = var.data_volume_size_gb
     volume_type           = "gp2"
     delete_on_termination = var.volume_delete_on_termination
-    encrypted             = var.volume_encrypted
   }
 
   launch_block_device_mappings {
@@ -32,7 +30,6 @@ source "amazon-ebs" "builder" {
     volume_size           = var.export_volume_size_gb
     volume_type           = "gp2"
     delete_on_termination = var.volume_delete_on_termination
-    encrypted             = var.volume_encrypted
   }
 
   security_group_filter {

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -12,24 +12,27 @@ source "amazon-ebs" "builder" {
   iam_instance_profile  = "packer-builders-${var.aws_region}"
 
   launch_block_device_mappings {
-    device_name = "/dev/xvda"
-    volume_size = var.root_volume_size_gb
-    volume_type = "gp2"
-    delete_on_termination = true
+    device_name           = "/dev/xvda"
+    volume_size           = var.root_volume_size_gb
+    volume_type           = "gp2"
+    delete_on_termination = var.volume_delete_on_termination
+    encrypted             = var.volume_encrypted
   }
 
   launch_block_device_mappings {
-    device_name = "/dev/xvdb"
-    volume_size = var.data_volume_size_gb
-    volume_type = "gp2"
-    delete_on_termination = false
+    device_name           = "/dev/xvdb"
+    volume_size           = var.data_volume_size_gb
+    volume_type           = "gp2"
+    delete_on_termination = var.volume_delete_on_termination
+    encrypted             = var.volume_encrypted
   }
 
   launch_block_device_mappings {
-    device_name = "/dev/xvdc"
-    volume_size = var.export_volume_size_gb
-    volume_type = "gp2"
-    delete_on_termination = false
+    device_name           = "/dev/xvdc"
+    volume_size           = var.export_volume_size_gb
+    volume_type           = "gp2"
+    delete_on_termination = var.volume_delete_on_termination
+    encrypted             = var.volume_encrypted
   }
 
   security_group_filter {

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -22,14 +22,14 @@ source "amazon-ebs" "builder" {
     device_name = "/dev/xvdb"
     volume_size = var.data_volume_size_gb
     volume_type = "gp2"
-    delete_on_termination = true
+    delete_on_termination = false
   }
 
   launch_block_device_mappings {
     device_name = "/dev/xvdc"
     volume_size = var.export_volume_size_gb
     volume_type = "gp2"
-    delete_on_termination = true
+    delete_on_termination = false
   }
 
   security_group_filter {

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -27,7 +27,7 @@ source "amazon-ebs" "builder" {
 
   launch_block_device_mappings {
     device_name = "/dev/xvdc"
-    volume_size = var.extract_volume_size_gb
+    volume_size = var.export_volume_size_gb
     volume_type = "gp2"
     delete_on_termination = true
   }

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -43,10 +43,22 @@ variable "configuration_group" {
   description = "The name of the group to which to add the instance for configuration purposes"
 }
 
+variable "root_volume_size_gb" {
+  type        = number
+  default     = 20
+  description = "The EC2 instance root volume size in Gibibytes (GiB)"
+}
+
 variable "data_volume_size_gib" {
   type        = number
-  default     = 1
+  default     = 100
   description = "The EC2 instance data volume size in Gibibytes (GiB)"
+}
+
+variable "extract_volume_size_gb" {
+  type        = number
+  default     = 100
+  description = "The size of the extract volume in gigabytes"
 }
 
 variable "force_delete_snapshot" {
@@ -65,12 +77,6 @@ variable "playbook_file_path" {
   type        = string
   default     = "../ansible/playbook.yml"
   description = "The relative path to the Ansible playbook file"
-}
-
-variable "root_volume_size_gb" {
-  type        = number
-  default     = 20
-  description = "The EC2 instance root volume size in Gibibytes (GiB)"
 }
 
 variable "ssh_private_key_file" {
@@ -99,12 +105,6 @@ variable "artifactory_version" {
 variable "resource_bucket_name" {
   type        = string
   description = "The name of the S3 resources bucket"
-}
-
-variable "swap_volume_size_gb" {
-  type        = number
-  default     = 0
-  description = "The size of the swap volume in gigabytes"
 }
 
 variable "jfrog_release_url" {

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -104,7 +104,7 @@ variable "version" {
 
 variable "artifactory_version" {
   type        = string
-  default     = "7.41.12"
+  default     = "7.63.12"
   description = "The semantic version number for the Artifactory release"
 }
 

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -49,7 +49,7 @@ variable "root_volume_size_gb" {
   description = "The EC2 instance root volume size in Gibibytes (GiB)"
 }
 
-variable "data_volume_size_gib" {
+variable "data_volume_size_gb" {
   type        = number
   default     = 100
   description = "The EC2 instance data volume size in Gibibytes (GiB)"

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -67,12 +67,6 @@ variable "volume_delete_on_termination" {
   description = "Indicates whether the EBS volume is deleted on instance termination"
 }
 
-variable "volume_encrypted" {
-  type        = bool
-  default     = true
-  description = "Indicates whether or not to encrypt the volume."
-}
-
 variable "force_delete_snapshot" {
   type        = bool
   default     = false

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -61,6 +61,18 @@ variable "export_volume_size_gb" {
   description = "The size of the export volume in gigabytes"
 }
 
+variable "volume_delete_on_termination" {
+  type        = bool
+  default     = false
+  description = "Indicates whether the EBS volume is deleted on instance termination"
+}
+
+variable "volume_encrypted" {
+  type        = bool
+  default     = true
+  description = "Indicates whether or not to encrypt the volume."
+}
+
 variable "force_delete_snapshot" {
   type        = bool
   default     = false

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -55,10 +55,10 @@ variable "data_volume_size_gb" {
   description = "The EC2 instance data volume size in Gibibytes (GiB)"
 }
 
-variable "extract_volume_size_gb" {
+variable "export_volume_size_gb" {
   type        = number
   default     = 100
-  description = "The size of the extract volume in gigabytes"
+  description = "The size of the export volume in gigabytes"
 }
 
 variable "force_delete_snapshot" {


### PR DESCRIPTION
DVOP-2453: Remove the swap volume which was 0GB and not being used. Add an extract volume & set extract & data volume sizes to 100gb.

Additional implementation:
Updated the launch_block_device_mappings config for /dev/sda1 to instead specify /dev/xvda
main.yml: Yum update on all packages & an instance reboot has been implemented
sources.pkr.hcl: delete on termination set to false for all volumes
variables.pkr.hcl: New variable: volume_delete_on_termination

Artifactory version upgraded to 7.63.12

New PR AMI now showing the existing data block device to be at 100gb from 1gb with additionally the extract volume now being present also at 100gb

All notes and screenshots can be viewed here:
https://companieshouse.atlassian.net/browse/DVOP-2453