### PR TITLE
Removing export volume - DVOP-2633

### DIFF
--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -56,6 +56,11 @@
     name: epel-release
     state: latest
 
+- name: install efs utils
+  yum:
+    name: amazon-efs-utils
+    state: latest
+
 - name: Configure JFrog environment
   copy:
     mode: 0644

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -27,14 +27,6 @@ source "amazon-ebs" "builder" {
     iops                  = var.volume_iops
   }
 
-  launch_block_device_mappings {
-    device_name           = "/dev/xvdc"
-    volume_size           = var.export_volume_size_gb
-    volume_type           = "gp3"
-    delete_on_termination = var.volume_delete_on_termination
-    iops                  = var.volume_iops
-  }
-
   security_group_filter {
     filters = {
       "group-name": "packer-builders-${var.aws_region}"

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -55,12 +55,6 @@ variable "data_volume_size_gb" {
   description = "The EC2 instance data volume size in Gibibytes (GiB)"
 }
 
-variable "export_volume_size_gb" {
-  type        = number
-  default     = 100
-  description = "The size of the export volume in gigabytes"
-}
-
 variable "volume_delete_on_termination" {
   type        = bool
   default     = false


### PR DESCRIPTION
Removing the launch_block_device_mapping & variable for the export_volume as no longer required due to the EFS implementation

Install amazon-efs-utils to enable efs auto mounting on instance