### PR TITLE
Enable compress for logrotate syslog configuration

### DIFF
--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -78,6 +78,5 @@
 
 - name: Create the EFS directory if it does not exist
   ansible.builtin.file:
-    path: /var/lib/artifactory
+    path: "/var/lib/artifactory"
     state: directory
-    mode: '0755'

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -75,3 +75,9 @@
     path: "/etc/logrotate.d/syslog"
     insertafter: 'sharedscripts'
     line: 'compress'
+
+- name: Create the EFS directory if it does not exist
+  ansible.builtin.file:
+    path: /var/lib/artifactory
+    state: directory
+    mode: '0755'

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -74,7 +74,7 @@
   ansible.builtin.lineinfile:
     path: "/etc/logrotate.d/syslog"
     insertafter: 'sharedscripts'
-    line: 'compress'
+    line: '    compress'
 
 - name: Create the EFS directory
   ansible.builtin.file:

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -69,3 +69,9 @@
     dest: "/etc/profile.d/artifactory.sh"
     content: |
       export JFROG_HOME="/opt/jfrog"
+
+- name: Enable compress for logrotate syslog configuration
+  ansible.builtin.lineinfile:
+    path: "/etc/logrotate.d/syslog.conf"
+    insertafter: 'sharedscripts'
+    line: 'compress'

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -76,7 +76,7 @@
     insertafter: 'sharedscripts'
     line: 'compress'
 
-- name: Create the EFS directory if it does not exist
+- name: Create the EFS directory
   ansible.builtin.file:
-    path: "/var/lib/artifactory"
+    path: /var/lib/artifactory
     state: directory

--- a/ansible/roles/artifactory/tasks/main.yml
+++ b/ansible/roles/artifactory/tasks/main.yml
@@ -72,6 +72,6 @@
 
 - name: Enable compress for logrotate syslog configuration
   ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/syslog.conf"
+    path: "/etc/logrotate.d/syslog"
     insertafter: 'sharedscripts'
     line: 'compress'


### PR DESCRIPTION
Enable compress for logrotate.d syslog configuration 

Compress option added successfully. /var/lib/artifactory/ directory for the EFS mount now also being created.

[DVOP-2682](https://companieshouse.atlassian.net/browse/DVOP-2682)

[DVOP-2682]: https://companieshouse.atlassian.net/browse/DVOP-2682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ